### PR TITLE
Fix monumental bug: most relevant rome was never shown

### DIFF
--- a/src/services/store.js
+++ b/src/services/store.js
@@ -31,7 +31,7 @@ export const reducer = (state = initialState, action) => {
 
         case 'SET_JOB_SUGGESTIONS':
             // Limit to ten results
-            const jobSuggestions = action.data.jobSuggestions.slice(1,10);
+            const jobSuggestions = action.data.jobSuggestions.slice(0,10);
             return { ...state, jobSuggestions }
 
         case 'SET_JOBS_CHOSEN':


### PR DESCRIPTION
jobSuggestions.slice(1,10) would skip 1st rome and only show 9 items.
jobSuggestions.slice(0,10) shows top 10 romes.
For example for "coiffeur", 2 rome codes match, only the 1st one
was relevant and has many results, but the widget would only
consider the second one! o_O